### PR TITLE
Fixed nullpointer when a string is request from a null clob field

### DIFF
--- a/src/main/java/com/github/davidmoten/rx/jdbc/Util.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/Util.java
@@ -449,6 +449,10 @@ public final class Util {
 
     private static <T> Object getObject(final ResultSet rs, Class<T> cls, int i) {
         try {
+            if (rs.getObject(i) == null) {
+                return null;
+            }
+
             final int type = rs.getMetaData().getColumnType(i);
             // TODO java.util.Calendar support
             // TODO XMLGregorian Calendar support


### PR DESCRIPTION
When a clob field has a NULL value and the string value was requested this resulted in a nullpointer exception. This pull request fixes that.
