### PR TITLE
Add named parameters

### DIFF
--- a/src/main/java/com/github/davidmoten/rx/jdbc/NamedParameters.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/NamedParameters.java
@@ -1,0 +1,68 @@
+package com.github.davidmoten.rx.jdbc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NamedParameters {
+
+    public static final JdbcQuery parse(String namedSql) {
+        // was originally using regular expressions, but they didn't work well
+        // for ignoring parameter-like strings inside quotes.
+        List<String> names = new ArrayList<String>();
+        int length = namedSql.length();
+        StringBuffer parsedQuery = new StringBuffer(length);
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        for (int i = 0; i < length; i++) {
+            char c = namedSql.charAt(i);
+            if (inSingleQuote) {
+                if (c == '\'') {
+                    inSingleQuote = false;
+                }
+            } else if (inDoubleQuote) {
+                if (c == '"') {
+                    inDoubleQuote = false;
+                }
+            } else {
+                if (c == '\'') {
+                    inSingleQuote = true;
+                } else if (c == '"') {
+                    inDoubleQuote = true;
+                } else if (c == ':' && i + 1 < length
+                        && Character.isJavaIdentifierStart(namedSql.charAt(i + 1))) {
+                    int j = i + 2;
+                    while (j < length && Character.isJavaIdentifierPart(namedSql.charAt(j))) {
+                        j++;
+                    }
+                    String name = namedSql.substring(i + 1, j);
+                    c = '?'; // replace the parameter with a question mark
+                    i += name.length(); // skip past the end if the parameter
+                    names.add(name);
+                }
+            }
+            parsedQuery.append(c);
+        }
+        return new JdbcQuery(parsedQuery.toString(), names);
+    }
+    
+    public static class JdbcQuery {
+        private final String sql;
+        private List<String> names;
+
+        public JdbcQuery(String sql, List<String> names) {
+            this.sql = sql;
+            this.names = names;;
+        }
+
+        public String sql() {
+            return sql;
+        }
+
+        public List<String> names() {
+            return names;
+        }
+        
+
+    }
+
+}

--- a/src/main/java/com/github/davidmoten/rx/jdbc/Parameter.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/Parameter.java
@@ -7,19 +7,24 @@ import rx.functions.Func1;
  */
 final class Parameter {
 
+    private final String name;
     /**
      * Actual query parameter value to be encapsulated.
      */
-    private final Object parameter;
+    private final Object value;
 
     /**
      * Constructor.
      * 
      * @param parameter
      */
-    Parameter(Object parameter) {
-        super();
-        this.parameter = parameter;
+    Parameter(Object value) {
+        this(null, value);
+    }
+
+    Parameter(String name, Object value) {
+        this.name = name;
+        this.value = value;
     }
 
     /**
@@ -27,15 +32,23 @@ final class Parameter {
      * 
      * @return
      */
-    Object getValue() {
-        return parameter;
+    Object value() {
+        return value;
+    }
+
+    boolean hasName() {
+        return name != null;
+    }
+
+    String name() {
+        return name;
     }
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("Parameter [parameter=");
-        builder.append(parameter);
+        builder.append("Parameter [value=");
+        builder.append(value);
         builder.append("]");
         return builder.toString();
     }

--- a/src/main/java/com/github/davidmoten/rx/jdbc/Query.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/Query.java
@@ -1,5 +1,7 @@
 package com.github.davidmoten.rx.jdbc;
 
+import java.util.List;
+
 import rx.Observable;
 import rx.Scheduler;
 
@@ -15,6 +17,15 @@ public interface Query {
      * @return jdbc sql
      */
     String sql();
+
+    /**
+     * Returns the list of names corresponding positionally to the ? characters in
+     * the sql. If names were not used then returns an empty list.
+     * 
+     * @return ist of names corresponding positionally to the ? characters in
+     *         the sql
+     */
+    List<String> names();
 
     /**
      * Returns the parameters for the query in order of appearance as ? markers

--- a/src/main/java/com/github/davidmoten/rx/jdbc/QueryBuilder.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/QueryBuilder.java
@@ -1,5 +1,7 @@
 package com.github.davidmoten.rx.jdbc;
 
+import com.github.davidmoten.util.Preconditions;
+
 import rx.Observable;
 
 /**
@@ -81,7 +83,16 @@ final class QueryBuilder {
                     "use parameters() method not the parameter() method for an Observable");
         parameters(Observable.just(value));
     }
-
+    
+    //TODO add javadoc
+    void parameter(String name, Object value) {
+        Preconditions.checkNotNull(name, "parameter name cannot be null");
+        if (value instanceof Observable)
+            throw new RuntimeException(
+                    "use parameters() method not the parameter() method for an Observable");
+        this.parameters =  parameters.concatWith(Observable.just(new Parameter(name, value)));
+    }
+    
     /**
      * Appends a dependency to the dependencies that have to complete their
      * emitting before the query is executed.

--- a/src/main/java/com/github/davidmoten/rx/jdbc/QueryUpdateOnSubscribe.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/QueryUpdateOnSubscribe.java
@@ -214,7 +214,7 @@ final class QueryUpdateOnSubscribe<T> implements OnSubscribe<T> {
             keysOption = Statement.NO_GENERATED_KEYS;
         }
         state.ps = state.con.prepareStatement(query.sql(), keysOption);
-        Util.setParameters(state.ps, parameters);
+        Util.setParameters(state.ps, parameters, query.names());
 
         if (subscriber.isUnsubscribed())
             return;

--- a/src/test/java/com/github/davidmoten/rx/jdbc/NamedParametersTest.java
+++ b/src/test/java/com/github/davidmoten/rx/jdbc/NamedParametersTest.java
@@ -1,0 +1,41 @@
+package com.github.davidmoten.rx.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.github.davidmoten.rx.jdbc.NamedParameters.JdbcQuery;
+
+public class NamedParametersTest {
+
+    @Test
+    public void testSelect() {
+        JdbcQuery r = NamedParameters
+                .parse("select a, b from tbl where a.name=:name and b.name=:name and c.description = :description");
+        assertEquals("select a, b from tbl where a.name=? and b.name=? and c.description = ?",
+                r.sql());
+        assertEquals(Arrays.asList("name", "name", "description"), r.names());
+    }
+    
+    @Test
+    public void testSelectWithOneNamedParameterAndColonNameInQuotes() {
+        JdbcQuery r = NamedParameters
+                .parse("select a, b from tbl where a.name=:name and b.name=':name'");
+        assertEquals("select a, b from tbl where a.name=? and b.name=':name'",
+                r.sql());
+        assertEquals(Arrays.asList("name"), r.names());
+    }
+    
+    @Test
+    public void testSelectWithNoNamedParameters() {
+        JdbcQuery r = NamedParameters
+                .parse("select a, b from tbl");
+        assertEquals("select a, b from tbl",
+                r.sql());
+        assertTrue(r.names().isEmpty());
+    }
+
+}


### PR DESCRIPTION
This PR adds named parameters support (See #24).

Examples:

```java
Observable<String> names = db
    .select("select name from person where score >= :min and score <=:max")
    .parameter("min", 24)
    .parameter("max", 26)
    .getAs(String.class);
```

Using a map of parameters:
```java
Map<String, Integer> map = new HashMap<String, Integer>();
map.put("min", 24);
map.put("max", 26);
Observable<String> names = db
    .select("select name from person where score >= :min and score <=:max")
    .parameters(map)
    .getAs(String.class);
```

Using an Observable of maps:
```java
Observable<String> names = db
    .select("select name from person where score >= :min and score <=:max")
    .parameters(Observable.just(map1, map2))
    .getAs(String.class);
```
