### PR TITLE
[WIP] Execute Update Query as Batch Update

### DIFF
--- a/src/main/java/com/github/davidmoten/rx/jdbc/Queries.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/Queries.java
@@ -94,4 +94,17 @@ final class Queries {
             return singleIntegerAfterDependencies(query).map(TO_EMPTY_PARAMETER_LIST);
     }
 
+
+    /**
+     * If the number of parameters in a query is >0 then group the parameters in lists of that number in size but only
+     * after the dependencies have been completed. Group these parameter lists again in batch lists of size
+     * {@code batchSize} to be executed in one batch execution. If the number of parameteres is zero then return an
+     * observable containing one item being an list containing one empty list.
+     * 
+     * @param query
+     * @return
+     */
+    static <T> Observable<List<List<Parameter>>> batchedBufferedParameters(QueryUpdate<T> query) {
+        return bufferedParameters(query).buffer(query.batchSize());
+    }
 }

--- a/src/test/java/com/github/davidmoten/rx/jdbc/QueriesTest.java
+++ b/src/test/java/com/github/davidmoten/rx/jdbc/QueriesTest.java
@@ -1,12 +1,74 @@
 package com.github.davidmoten.rx.jdbc;
 
+import static com.github.davidmoten.rx.jdbc.DatabaseCreator.connectionProvider;
+import static com.github.davidmoten.rx.jdbc.DatabaseCreator.createDatabase;
+import static java.util.Collections.nCopies;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
+import rx.Observable;
 
 public class QueriesTest {
+
+    private static final List<Integer> LIST_WITH_100_THREES = new ArrayList<>(nCopies(100, 3));
 
     @Test
     public void obtainCoverageOfPrivateConstructor() {
         TestingUtil.instantiateUsingPrivateConstructor(Queries.class);
     }
 
+    @Test
+    public void executeQueryUpdateWithDefaultBatchSize() {
+        Connection con = connectionProvider().get();
+        createDatabase(con);
+
+        List<Integer> count = new QueryUpdate.Builder("update person set score = ?", Database.from(con))
+                .parameters(Observable.range(1, 100))
+                .count()
+                .toList()
+                .toBlocking()
+                .single();
+
+        assertThat(count, is(equalTo(LIST_WITH_100_THREES)));
+    }
+
+    @Test
+    public void executeQueryUpdateWithBatchSizeOf10() {
+        Connection con = connectionProvider().get();
+        createDatabase(con);
+        Database db = Database.from(con);
+
+        List<Integer> count = new QueryUpdate.Builder("update person set score = ?", db)
+                .parameters(Observable.range(1, 100))
+                .batchSize(10)
+                .count()
+                .toList()
+                .toBlocking()
+                .single();
+
+        assertThat(count, is(equalTo(LIST_WITH_100_THREES)));
+    }
+
+    @Test
+    public void setBatchSizeGreaterThanQueryExecutionCount() {
+        Connection con = connectionProvider().get();
+        createDatabase(con);
+        Database db = Database.from(con);
+
+        List<Integer> count = new QueryUpdate.Builder("update person set score = ?", db)
+                .parameters(Observable.range(1, 100))
+                .batchSize(10000)
+                .count()
+                .toList()
+                .toBlocking()
+                .single();
+
+        assertThat(count, is(equalTo(LIST_WITH_100_THREES)));
+    }
 }


### PR DESCRIPTION
A simple approach to execute batch updates. I needed this for a work project executing ~800M insert queries per run. Hope this functionality will be added this way or another as I really like avoiding java.sql.*.

I marked it as "work in progress" because it lacks test cases and documentation and probably needs some code refactoring.