### PR TITLE
fix to autoMap

### DIFF
--- a/src/main/java/com/github/davidmoten/rx/jdbc/ResultSetCache.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/ResultSetCache.java
@@ -24,7 +24,7 @@ class ResultSetCache {
         try {
             ResultSetMetaData metadata = rs.getMetaData();
             for (int i = 1; i <= metadata.getColumnCount(); i++) {
-                map.put(metadata.getColumnName(i), i);
+                map.put(metadata.getColumnName(i).toUpperCase(), i);
             }
             return map;
         } catch (SQLException e) {


### PR DESCRIPTION
Util.java:368 line contains the following statement:
```java
index = colIndexes.get(name.toUpperCase());
```
in order to get this working the mapping also has to have keys in upper case