### PR TITLE
fixing double colon casts in PostgreSQL

### DIFF
--- a/src/main/java/com/github/davidmoten/rx/jdbc/NamedParameters.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/NamedParameters.java
@@ -5,12 +5,12 @@ import java.util.List;
 
 public class NamedParameters {
 
-    public static final JdbcQuery parse(String namedSql) {
+    public static JdbcQuery parse(String namedSql) {
         // was originally using regular expressions, but they didn't work well
         // for ignoring parameter-like strings inside quotes.
         List<String> names = new ArrayList<String>();
         int length = namedSql.length();
-        StringBuffer parsedQuery = new StringBuffer(length);
+        StringBuilder parsedQuery = new StringBuilder(length);
         boolean inSingleQuote = false;
         boolean inDoubleQuote = false;
         for (int i = 0; i < length; i++) {
@@ -28,7 +28,7 @@ public class NamedParameters {
                     inSingleQuote = true;
                 } else if (c == '"') {
                     inDoubleQuote = true;
-                } else if (c == ':' && i + 1 < length
+                } else if (c == ':' && i + 1 < length && !doubleColonCast(namedSql,i)
                         && Character.isJavaIdentifierStart(namedSql.charAt(i + 1))) {
                     int j = i + 2;
                     while (j < length && Character.isJavaIdentifierPart(namedSql.charAt(j))) {
@@ -43,6 +43,10 @@ public class NamedParameters {
             parsedQuery.append(c);
         }
         return new JdbcQuery(parsedQuery.toString(), names);
+    }
+
+    private static boolean doubleColonCast(String sql, int i) {
+        return ':' == sql.charAt(i + 1) || (i > 0  && ':' == sql.charAt(i - 1));
     }
 
     public static class JdbcQuery {

--- a/src/test/java/com/github/davidmoten/rx/jdbc/NamedParametersTest.java
+++ b/src/test/java/com/github/davidmoten/rx/jdbc/NamedParametersTest.java
@@ -40,4 +40,12 @@ public class NamedParametersTest {
         DatabaseCreator.db().select("select name from person where name = :name").count()
                 .subscribe();
     }
+
+    @Test
+    public void testDoubleColonCastNotProcessed() {
+        JdbcQuery r = NamedParameters.parse(
+                "select a::varchar, b from tbl where a.name=:name");
+        assertEquals("select a::varchar, b from tbl where a.name=?", r.sql());
+        assertEquals(Arrays.asList("name"), r.names());
+    }
 }


### PR DESCRIPTION
In previous versions 0.5.x, queries made to PostgreSQL with explicit casts were supported.
In example, queries like:
**select a::varchar from tbl** 
But with the named parameter changes in 0.6.x releases, these queries stopped working.
I've added a small piece of code that handles these cases and one tests that verifies it works.
Thanks for a great product :)

More info:
(https://www.microolap.com/products/connectivity/postgresdac/help/tipsandtricks_typecasting.htm)
