### PR TITLE
Implementation of String arrays in queries/insert/updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 .project
 .classpath
 .settings
+.idea
+*.iml

--- a/src/main/java/com/github/davidmoten/rx/jdbc/QuerySelectOnSubscribe.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/QuerySelectOnSubscribe.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
+import rx.Subscription;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
 
@@ -107,7 +108,10 @@ final class QuerySelectOnSubscribe<T> implements OnSubscribe<T> {
             state.ps = state.con.prepareStatement(query.sql(), ResultSet.TYPE_FORWARD_ONLY,
                     ResultSet.CONCUR_READ_ONLY);
             log.debug("setting parameters");
-            Util.setParameters(state.ps, parameters, query.names());
+            List<Subscription> subscriptions = Util.setParameters(state.ps, parameters, query.names());
+            for (Subscription subscription : subscriptions) {
+                subscriber.add(subscription);
+            }
         }
     }
 

--- a/src/main/java/com/github/davidmoten/rx/jdbc/QueryUpdateOnSubscribe.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/QueryUpdateOnSubscribe.java
@@ -214,7 +214,10 @@ final class QueryUpdateOnSubscribe<T> implements OnSubscribe<T> {
             keysOption = Statement.NO_GENERATED_KEYS;
         }
         state.ps = state.con.prepareStatement(query.sql(), keysOption);
-        Util.setParameters(state.ps, parameters, query.names());
+        List<Subscription> subscriptions = Util.setParameters(state.ps, parameters, query.names());
+        for (Subscription subscription : subscriptions) {
+            subscriber.add(subscription);
+        }
 
         if (subscriber.isUnsubscribed())
             return;

--- a/src/test/java/com/github/davidmoten/rx/jdbc/DatabaseCreator.java
+++ b/src/test/java/com/github/davidmoten/rx/jdbc/DatabaseCreator.java
@@ -84,6 +84,10 @@ public class DatabaseCreator {
             c.prepareStatement(
                     "create table note(id bigint auto_increment primary key, text varchar(255))")
                     .execute();
+
+            c.prepareStatement(
+                    "create table person_lines (name varchar(50) not null,  lines array)")
+                    .execute();
         } catch (SQLException e) {
             throw new SQLRuntimeException(e);
         }

--- a/src/test/java/com/github/davidmoten/rx/jdbc/DatabaseTestBase.java
+++ b/src/test/java/com/github/davidmoten/rx/jdbc/DatabaseTestBase.java
@@ -776,6 +776,16 @@ public abstract class DatabaseTestBase {
     }
 
     @Test
+    public void testStringArray() throws Exception {
+        Database db = db();
+        String[] lines = new String[] {"123 Main St.", "Nowhere, USA"};
+
+        int actual = db.update("INSERT INTO person_lines (name, lines) VALUES (?, ?)")
+                .parameters("fred", lines).count().first().toBlocking().single();
+        assertEquals(1, actual);
+    }
+
+    @Test
     public void testDatabaseBuilder() {
         Database.builder().connectionProvider(connectionProvider())
                 .nonTransactionalSchedulerOnCurrentThread().build();


### PR DESCRIPTION
Relates to #33 

I went with a very narrow fix for solving my immediate use case. Support for varchar SQL arrays on non-H2 databases. I have only tested this against Postgres, though I did at least look at Oracle documentation for arrays to see that they create arrays in the same manner.

I did try a few things for more general purpose array handling but I was unable to easily infer the type from the Postgres metadata so I was wary of attempting anything too fancy and likely hurting any chance of cross database compatibility.

I still think it would be good to have a more general purpose pluggable mechanism as we discussed in #33 but that would take some deeper architectural deviations then I am comfortable undertaking at this time.

Please, let me know what your thoughts are.