### PR TITLE
Batch Updates WIP (Tom's Attempt)

### DIFF
--- a/src/main/java/com/github/davidmoten/rx/jdbc/PreparedStatementBatch.java
+++ b/src/main/java/com/github/davidmoten/rx/jdbc/PreparedStatementBatch.java
@@ -30,6 +30,8 @@ class PreparedStatementBatch implements PreparedStatement {
     private int keysOption;
 
     PreparedStatementBatch(PreparedStatement ps, String sql, int keysOption) {
+        if (ps instanceof PreparedStatementBatch) throw new RuntimeException("PreparedStatementBatch cannot delegate to a PreparedStatementBatch");
+
         this.ps = ps;
         this.sql = sql;
         this.keysOption = keysOption;

--- a/src/test/java/com/github/davidmoten/rx/jdbc/DatabaseCreator.java
+++ b/src/test/java/com/github/davidmoten/rx/jdbc/DatabaseCreator.java
@@ -24,6 +24,11 @@ public class DatabaseCreator {
     public static Database db() {
         ConnectionProvider cp = connectionProvider();
         Connection con = cp.get();
+        try {
+            con.setAutoCommit(false);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
         createDatabase(con);
         try {
             con.close();


### PR DESCRIPTION
Hey David, 

I was having issues with the batching and I'm not quite sure if it was working. I went ahead and tried to hack out some modifications to successfully get it operational. I think I was able to get a `State` shared successfully across all batches (and batching does indeed seem to be occurring now). However a few unit tests are failing probably likely due to auto-commit not being considered, and perhaps I broke a few things that I'm still seeking to understanding. 

Basically, my strategy is to do a double-buffer of the parameters, one for the parameter count in a query and another for the batch sizing. So, it is returning an `Observable<List<List<Parameter>>`. 

Here is a modification I did in `Queries.java`.

```java

    static Observable<List<List<Parameter>>> bufferedParameters(Query query, int batchSize) {
        int numParamsPerQuery = numParamsPerQuery(query);
        if (numParamsPerQuery > 0)
            // we don't check that parameters is empty after this because by
            // general design we want nothing to happen if a query is passed no
            // parameters when it expects them
            return parametersAfterDependencies(query).concatMap(FLATTEN_NAMED_MAPS)
                    .buffer(numParamsPerQuery)
                    .buffer(batchSize);
        else
            return singleIntegerAfterDependencies(query).map(TO_EMPTY_PARAMETER_LIST);
    }
```

In `QueryUpdate.java`, I declare a `State` for the entire subscription and pass it down to the `QueryUpdateOnSubscribe`. 

```java
    static <T> Observable<T> get(final QueryUpdate<T> queryUpdate) {
        return Observable.defer(new Func0<Observable<T>>() {

            @Override
            public Observable<T> call() {
                State state = new State();
                return bufferedParameters(queryUpdate, queryUpdate.batchSize)
                        // execute query for each set of parameters
                        .concatMap(queryUpdate.executeOnce(state));
            }
        });
    }
```

And finally on the `performUpdate()` in `QueryUpdateOnSubscribe`, I process each "batch" of parameters in a `for` loop. 

```java
    private void performUpdate(final Subscriber<? super T> subscriber, State state)
            throws SQLException {
        if (subscriber.isUnsubscribed()) {
            return;
        }
        int keysOption;
        if (query.returnGeneratedKeys()) {
            keysOption = Statement.RETURN_GENERATED_KEYS;
        } else {
            keysOption = Statement.NO_GENERATED_KEYS;
        }
        state.ps = state.con.prepareStatement(query.sql(), keysOption);


        if (subscriber.isUnsubscribed())
            return;

        int count = 0;
        for (List<Parameter> parameters: batchedParameters) {
            try {
                Util.setParameters(state.ps, parameters, query.names());

                log.debug("executing sql={}, parameters {}", query.sql(), parameters);
                count += state.ps.executeUpdate();
                log.debug("executed ps={}", state.ps);

            } catch (SQLException e) {
                throw new SQLException("failed to execute sql=" + query.sql(), e);
            }
        }

        if (query.returnGeneratedKeys()) {
            log.debug("getting generated keys");
            ResultSet rs = state.ps.getGeneratedKeys();
            log.debug("returned generated key result set {}", rs);
            state.rs = rs;
            Observable<Parameter> params = Observable.just(new Parameter(state));
            Observable<Object> depends = Observable.empty();
            Observable<T> o = new QuerySelect(QuerySelect.RETURN_GENERATED_KEYS, params,
                    depends, query.context(), query.context().resultSetTransform())
                    .execute(query.returnGeneratedKeysFunction());
            Subscriber<T> sub = createSubscriber(subscriber);
            o.unsafeSubscribe(sub);
        }

        if (!query.returnGeneratedKeys()) {
            // must close before onNext so that connection is released and is
            // available to a query that might process the onNext
            //close(state);
            if (subscriber.isUnsubscribed())
                return;
            log.debug("onNext");
            subscriber.onNext((T) (Integer) count);
        }
    }
```

However, I am having a few technical issues that I will seek to work out. But I wanted to show you the general idea I am workin towards. 
