### PR TITLE
replace old "lift" calls in README for new "compose" calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Include this maven dependency in your pom (available in Maven Central):
 <dependency>
     <groupId>com.github.davidmoten</groupId>
     <artifactId>rxjava-jdbc</artifactId>
-    <version>0.7.2</version>
+    <version>0.7.4</version>
 </dependency>
 ```
 


### PR DESCRIPTION
I started using rxjava-jdbc recently and I was a bit confused, as the README instructions did not reflect the latest changes in the API.

I updated the README file to avoid this situation.

EDIT: I also updated the maven dependency snippet to show 0.7.4 instead of 0.7.2.