### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ If you nominate an interface then dynamic proxies (a java reflection feature) ar
 
 If you nominate a concrete class then the columns of the result set are mapped to parameters in the constructor (again using reflection).
 
-###Automap using an interface
+### Automap using an interface
 
 Create an annotated interface (introduced in *rxjava-jdbc* 0.5.8):
 
@@ -377,7 +377,7 @@ Observable<Person> persons = db
 ```
 
 
-###Automap using a concrete class 
+### Automap using a concrete class 
 
 Given this class:
 ```java
@@ -416,7 +416,7 @@ Note that automappings do not occur to primitives so use ```Long``` instead of `
 Tuples
 ---------------
 Typed tuples can be returned in an ```Observable```:
-###Tuple2
+### Tuple2
 ```java
 Tuple2<String, Integer> tuple = db
 		.select("select name,score from person where name >? order by name")
@@ -427,7 +427,7 @@ assertEquals("MARMADUKE", tuple.value1());
 assertEquals(25, (int) tuple.value2());
 ```
 Similarly for ```Tuple3```, ```Tuple4```, ```Tuple5```, ```Tuple6```, ```Tuple7```, and finally 
-###TupleN
+### TupleN
 ```java
 TupleN<String> tuple = db
 		.select("select name, lower(name) from person order by name")
@@ -613,7 +613,7 @@ When you want a statement to participate in a transaction then either it should
 * depend on ```db.beginTransaction()``` 
 * be passed parameters or dependencies through ```db.beginTransactionOnNext()```
 
-###Transactions as dependency
+### Transactions as dependency
 ```java
 Observable<Boolean> begin = db.beginTransaction();
 Observable<Integer> updateCount = db
@@ -641,7 +641,7 @@ long count = db
 assertEquals(3, count);
 ```
 
-###onNext Transactions
+### onNext Transactions
 ```java
 List<Integer> mins = Observable
     // do 3 times

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,32 +1,32 @@
 Release Notes
 ---------------
-###Version 0.4-SNAPSHOT
+### Version 0.4-SNAPSHOT
 
-###Version 0.3 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.3%7Cjar))
+### Version 0.3 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.3%7Cjar))
 * add ```Database.run``` overload with ```Charset``` parameter
 * [pull 10](https://github.com/davidmoten/rxjava-jdbc/pull/10) Add backpressure suppport for ```QuerySelectOperator```
 * upgrade rxjava dependency to 0.20.0 which includes backpressure
 
-###Version 0.2 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.2%7Cjar))
+### Version 0.2 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.2%7Cjar))
 * upgrade rxjava dependency to 0.19.6
 * use lazy evaluation in logging
 * [pull 4] (https://github.com/davidmoten/rxjava-jdbc/pull/4) Add test scope to mockito dependency
 * [pull 6] (https://github.com/davidmoten/rxjava-jdbc/pull/6) add support for null insert/update of clobs and blobs
 
-###Version 0.1.3 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1.3%7Cjar))
+### Version 0.1.3 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1.3%7Cjar))
 * upgrade rxjava dependency to 0.17.6 (retry operator was broken in 0.17.5)
 * upgrade c3p0, h2, slf4j dependencies to latest
 * change ```Database.Builder``` method for specifiying connection pool
 * add username and password parameters to ```Database.Builder```, ```Database.from()```
 
-###Version 0.1.2 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1.2%7Cjar))
+### Version 0.1.2 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1.2%7Cjar))
 * [issue #1](https://github.com/davidmoten/rxjava-jdbc/issues/1) use rxjava 0.17.4
 * add ```Database.fromContext(jndiResource)``` for JNDI lookup of DataSource 
 * [issue #2](https://github.com/davidmoten/rxjava-jdbc/issues/2) queries synchronous by default (scheduled using ```Schedulers.trampoline()```)
 * [pull 3](https://github.com/davidmoten/rxjava-jdbc/pull/3) run all database tests sync and async 
 
-###Version 0.1.1 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1.1%7Cjar))
+### Version 0.1.1 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1.1%7Cjar))
 * replaced use of ```flatMap``` with ```concatMap``` to limit possible async side effects on specifying parameter observables to queries
 
-###Version 0.1 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1%7Cjar))
+### Version 0.1 ([Maven Central](http://search.maven.org/#artifactdetails%7Ccom.github.davidmoten%7Crxjava-jdbc%7C0.1%7Cjar))
 * initial release


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
